### PR TITLE
Bug 1129890: Remove SimpleAntiSpam extension.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -69,10 +69,6 @@
 	path = extensions/SemanticWatchlist
 	url = https://github.com/SemanticMediaWiki/SemanticWatchlist.git
 	branch = master
-[submodule "extensions/SimpleAntiSpam"]
-	path = extensions/SimpleAntiSpam
-	url = https://git.wikimedia.org/git/mediawiki/extensions/SimpleAntiSpam.git
-	branch = REL1_19
 [submodule "extensions/Smartsheet-MediaWiki-Extension"]
 	path = extensions/Smartsheet-MediaWiki-Extension
 	url = https://github.com/bensternthal/Smartsheet-MediaWiki-Extension.git

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -516,9 +516,6 @@ $wgReCaptchaPrivateKey = $SECRETS_wgReCaptchaPrivateKey;
 require_once("$IP/../extensions/googleAnalytics/googleAnalytics.php");
 $wgGoogleAnalyticsAccount = $SECRETS_wgGoogleAnalyticsAccount;
 
-# bug 860214
-require_once("$IP/../extensions/SimpleAntiSpam/SimpleAntiSpam.php");
-
 # bug 855309
 require_once("$IP/../extensions/SubPageList/SubPageList.php");
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1129890