### PR TITLE
Specify that svg is default filetype for GraphViz renderings.

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -636,4 +636,6 @@ $wgPFEnableStringFunctions = true;
 require_once("$IP/../extensions/Widgets/Widgets.php");
 require_once("$IP/../extensions/GraphViz/GraphViz.php");
 
+// Set default image type for GraphViz rendering
+$wgGraphVizSettings->defaultImageType = 'svg';
 // EOF


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1136485#c8