### PR TITLE
Etherpad-Importer: Remove <br /> at end of line

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -643,6 +643,7 @@ require_once "$IP/../extensions/ImportFromEtherpad/ImportFromEtherpad.php";
 // these regexs replace strings in the converted mediawiki content
 $wgImportFromEtherpadSettings->contentRegexs[] = array("\n\n","\n");
 $wgImportFromEtherpadSettings->contentRegexs[] = array("<br \/>\n<br \/>","\n");
+$wgImportFromEtherpadSettings->contentRegexs[] = array("(?!^)<br \/>\n\n","\n\n");
 $wgImportFromEtherpadSettings->contentRegexs[] = array("\x{00a0}+","");
 $wgImportFromEtherpadSettings->contentRegexs[] = array("\[https?:\/\/wiki\.mozilla\.org\/Category:(.+?) https?:\/\/wiki\.mozilla\.org\/Category:(.+?)\]","[[:Category:$1]]");
 $wgImportFromEtherpadSettings->contentRegexs[] = array("\[https?:\/\/wiki\.mozilla\.org\/(.+?) https?:\/\/wiki\.mozilla\.org\/(.+?)\]","[[$1]]");


### PR DESCRIPTION
If a `<br />` is immediately followed by a blank line (`\n\n`), remove the `<br />` to avoid multiple blank lines. Real life example where this makes sense is https://demeeting.etherpad.mozilla.org/2015-04-09.

@christi3k r?