### PR TITLE
Remove DocShell redirects from configuration files.

### DIFF
--- a/htaccess
+++ b/htaccess
@@ -16,7 +16,6 @@
   RewriteRule ^/GeckoDev([/\?].*|$) /wiki/GeckoDev:Home_Page? [R,L]
   RewriteRule ^/XULDev([/\?].*|$) /wiki/XUL:Home_Page? [R,L]
   RewriteRule ^/Calendar([/\?].*|$) /wiki/Calendar:Home_Page? [R,L]
-  RewriteRule ^/DocShell([/\?].*|$) /wiki/DocShell:Home_Page? [R,L]
   RewriteRule ^/SVG([/\?].*|$) /wiki/SVG:Home_Page? [R,L]
   RewriteRule ^/SVGDev([/\?].*|$) /wiki/SVGDev:Home_Page? [R,L]
   RewriteRule ^/mozwiki https://wiki.mozilla.org/ [R,L]

--- a/tools/wiki-dev.allizom.org.conf
+++ b/tools/wiki-dev.allizom.org.conf
@@ -72,7 +72,6 @@ Define logdir   /var/log/apache2/${site}.${domain}
     RewriteRule ^/GeckoDev([/\?].*|$) /core/GeckoDev:Home_Page? [R,L]
     RewriteRule ^/XULDev([/\?].*|$) /core/XUL:Home_Page? [R,L]
     RewriteRule ^/Calendar([/\?].*|$) /core/Calendar:Home_Page? [R,L]
-    RewriteRule ^/DocShell([/\?].*|$) /core/DocShell:Home_Page? [R,L]
     RewriteRule ^/SVG([/\?].*|$) /core/SVG:Home_Page? [R,L]
     RewriteRule ^/SVGDev([/\?].*|$) /core/SVGDev:Home_Page? [R,L]
     RewriteRule ^/mozwiki https://${site}.${domain}/ [R,L]

--- a/tools/wiki-sandbox.allizom.org.conf
+++ b/tools/wiki-sandbox.allizom.org.conf
@@ -72,7 +72,6 @@ Define logdir   /var/log/apache2/${site}.${domain}
     RewriteRule ^/GeckoDev([/\?].*|$) /core/GeckoDev:Home_Page? [R,L]
     RewriteRule ^/XULDev([/\?].*|$) /core/XUL:Home_Page? [R,L]
     RewriteRule ^/Calendar([/\?].*|$) /core/Calendar:Home_Page? [R,L]
-    RewriteRule ^/DocShell([/\?].*|$) /core/DocShell:Home_Page? [R,L]
     RewriteRule ^/SVG([/\?].*|$) /core/SVG:Home_Page? [R,L]
     RewriteRule ^/SVGDev([/\?].*|$) /core/SVGDev:Home_Page? [R,L]
     RewriteRule ^/mozwiki https://${site}.${domain}/ [R,L]


### PR DESCRIPTION
This redirect is covering up changes made on the content of the wiki.