### PR TITLE
install and configure New Relic PHP agent

### DIFF
--- a/nubis/puppet/files/confd/conf.d/newrelic.toml
+++ b/nubis/puppet/files/confd/conf.d/newrelic.toml
@@ -1,0 +1,10 @@
+[template]
+src = "newrelic.tmpl"
+dest = "/etc/apache2/conf-available/newrelic.conf"
+prefix = "/%%PROJECT%%-%%ENVIRONMENT%%/%%ENVIRONMENT%%"
+
+keys = [
+    "/config"
+]
+
+reload_cmd = "/etc/init.d/apache2 restart"

--- a/nubis/puppet/files/confd/templates/newrelic.tmpl
+++ b/nubis/puppet/files/confd/templates/newrelic.tmpl
@@ -1,0 +1,4 @@
+<IfModule mod_php5.c>
+  php_flag newrelic.appname = '{{ getv "/config/newrelic/app_name" }}'
+  php_flag newrelic.license = '{{ getv "/config/newrelic/license_key" }}'
+</IfModule>

--- a/nubis/puppet/newrelic.pp
+++ b/nubis/puppet/newrelic.pp
@@ -1,0 +1,24 @@
+apt::source { 'newrelic':
+  comment  => 'This is the New Relic package repository',
+  location => 'http://apt.newrelic.com/debian/',
+  release  => 'newrelic',
+  repos    => 'newrelic non-free',
+  key      => {
+    'id'   => 'B60A3EC9BC013B9C23790EC8B31B29E5548C16BF',
+  },
+  include  => {
+    'deb'  => true,
+  },
+}
+
+package { 'newrelic-php5':
+  ensure  => 'installed',
+  require => Apt::Source['newrelic'],
+}
+
+exec { 'newrelic-install':
+  command     => 'newrelic-install install',
+  path        => ['/usr/bin', '/bin'],
+  environment => ['NR_INSTALL_SILENT=true'],
+  require     => Package['newrelic-php5'],
+}

--- a/nubis/puppet/web.pp
+++ b/nubis/puppet/web.pp
@@ -33,6 +33,7 @@ apache::vhost { $project_name:
 
 	# Compress custom deflate types
 	Include /etc/apache2/mods-enabled/deflate.conf
+	Include /etc/apache2/mods-enabled/newrelic.conf
 	AddOutputFilterByType DEFLATE text/javascript
     ",
     headers            => [


### PR DESCRIPTION
This PR satisfies issues #54.

I think I've found the simplest method to configure the agent in this environment. After running `newrelic-install install`, I wasn't sure where the `newrelic.ini` configuration file would be located and I was worried that it would change when PHP is upgraded down the road. Instead of trying to template that config and write it with `confd`, I followed the New Relic's "Apache per-directory settings for PHP" recommendations. We do not have multiple applications running on these servers but this did make it easy to set agent configuration variables. More details here:

https://docs.newrelic.com/docs/agents/php-agent/configuration/php-directory-ini-settings

An Apache configuration file was is created with `confd` from a template. The correct application name, depending on environment, is embedded in that file. From here, Apache simply includes it. These values should override the default configuration file (`newrelic.ini`).

Once this is merged, we'll need to test in stage. It's unclear if this will work as-is.