### PR TITLE
second install of New Relic with proper apt repo release

### DIFF
--- a/nubis/puppet/files/confd/conf.d/newrelic.toml
+++ b/nubis/puppet/files/confd/conf.d/newrelic.toml
@@ -1,0 +1,10 @@
+[template]
+src = "newrelic.tmpl"
+dest = "/etc/apache2/conf-available/newrelic.conf"
+prefix = "/%%PROJECT%%-%%ENVIRONMENT%%/%%ENVIRONMENT%%"
+
+keys = [
+    "/config"
+]
+
+reload_cmd = "/etc/init.d/apache2 restart"

--- a/nubis/puppet/files/confd/templates/newrelic.tmpl
+++ b/nubis/puppet/files/confd/templates/newrelic.tmpl
@@ -1,0 +1,4 @@
+<IfModule mod_php5.c>
+  php_flag newrelic.appname = '{{ getv "/config/newrelic/app_name" }}'
+  php_flag newrelic.license = '{{ getv "/config/newrelic/license_key" }}'
+</IfModule>

--- a/nubis/puppet/newrelic.pp
+++ b/nubis/puppet/newrelic.pp
@@ -1,0 +1,24 @@
+apt::source { 'newrelic':
+  comment  => 'This is the New Relic package repository',
+  location => 'http://apt.newrelic.com/debian/',
+  release  => 'non-free',
+  repos    => 'newrelic non-free',
+  key      => {
+    'id'   => 'B60A3EC9BC013B9C23790EC8B31B29E5548C16BF',
+  },
+  include  => {
+    'deb'  => true,
+  },
+}
+
+package { 'newrelic-php5':
+  ensure  => 'installed',
+  require => Apt::Source['newrelic'],
+}
+
+exec { 'newrelic-install':
+  command     => 'newrelic-install install',
+  path        => ['/usr/bin', '/bin'],
+  environment => ['NR_INSTALL_SILENT=true'],
+  require     => Package['newrelic-php5'],
+}

--- a/nubis/puppet/web.pp
+++ b/nubis/puppet/web.pp
@@ -33,6 +33,7 @@ apache::vhost { $project_name:
 
 	# Compress custom deflate types
 	Include /etc/apache2/mods-enabled/deflate.conf
+  Include /etc/apache2/mods-enabled/newrelic.conf
 	AddOutputFilterByType DEFLATE text/javascript
     ",
     headers            => [

--- a/nubis/puppet/web.pp
+++ b/nubis/puppet/web.pp
@@ -33,7 +33,7 @@ apache::vhost { $project_name:
 
 	# Compress custom deflate types
 	Include /etc/apache2/mods-enabled/deflate.conf
-  Include /etc/apache2/mods-enabled/newrelic.conf
+	Include /etc/apache2/mods-enabled/newrelic.conf
 	AddOutputFilterByType DEFLATE text/javascript
     ",
     headers            => [


### PR DESCRIPTION
PR #55 failed because the configured apt repository release was incorrect. This PR should address that issue.