### PR TITLE
older versions of apt Puppet module require an explicit include

### DIFF
--- a/nubis/puppet/newrelic.pp
+++ b/nubis/puppet/newrelic.pp
@@ -1,3 +1,5 @@
+include apt
+
 apt::source { 'newrelic':
   comment  => 'This is the New Relic package repository',
   location => 'http://apt.newrelic.com/debian/',


### PR DESCRIPTION
This has been tested in the Nubis training account and I would expect it to work now. This deployment repository specifies version 2.0.1 of the `apt` Puppet module. I was testing around version 4.x. This change seems to address the differences.