### PR TITLE
fixed incorrect include path

### DIFF
--- a/nubis/puppet/web.pp
+++ b/nubis/puppet/web.pp
@@ -33,7 +33,7 @@ apache::vhost { $project_name:
 
 	# Compress custom deflate types
 	Include /etc/apache2/mods-enabled/deflate.conf
-	Include /etc/apache2/mods-enabled/newrelic.conf
+	Include /etc/apache2/conf-available/newrelic.conf
 	AddOutputFilterByType DEFLATE text/javascript
     ",
     headers            => [


### PR DESCRIPTION
This addresses an issue I introduced with a previous PR. Apache has been unable to find the `newrelic.conf` file which has prevented it from starting.