### PR TITLE
fixes broken path to New Relic configuration file

### DIFF
--- a/nubis/puppet/files/confd/conf.d/newrelic.toml
+++ b/nubis/puppet/files/confd/conf.d/newrelic.toml
@@ -1,6 +1,6 @@
 [template]
 src = "newrelic.tmpl"
-dest = "/etc/php5/apache2/conf.d/newrelic.ini"
+dest = "/etc/php/7.0/apache2/conf.d/newrelic.ini"
 prefix = "/%%PROJECT%%-%%ENVIRONMENT%%/%%ENVIRONMENT%%"
 
 keys = [


### PR DESCRIPTION
When time permits, we should look at alternative configuration methods. Hard coding the path is not ideal but I don't want to create unnecessary overhead to identify the correct path. Reviewing the New Relic documentation to find configuration options should be done next. Setting configuration values, like the license key, are probably best managed as environment variables.