### PR TITLE
fix(packer): add steps to remove expired CA from AMI

### DIFF
--- a/nubis/builder/provisioners.json
+++ b/nubis/builder/provisioners.json
@@ -35,7 +35,10 @@
     {
       "type": "shell",
       "inline": [
-        "sudo chown -R root:root /var/www/{{user `project_name`}}"
+        "sudo chown -R root:root /var/www/{{user `project_name`}}",
+        "sudo /bin/rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt",
+        "sudo /bin/sed -i '/DST_Root_CA_X3.crt/d' /etc/ca-certificates.conf",
+        "sudo /usr/sbin/update-ca-certificates"
       ],
       "order": "6"
     }


### PR DESCRIPTION
When bugzilla moved to GCE a bug was triggered where the instances are relying on old and outdata CAs included with Ubuntu 16.04, removing the CA in question fixes the issue - this has been verified in stage/prod by appending commands to the LCs user-data.
I'm unsure where user-data is defined for wiki/nubis, searching the code base I cannot find any definitions for it, or for ASG/LC. 
According to documentation here: https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27924813/Nubis+brain+dump "Every push to the app repo will run an ami build using packer and will automatically go on to the next job which is a deployment.", which is supposed to then replace the ASG (and I'm assuming the LC).
The commands added to the packer provisioner in this commit should accomplish the same steps that have been manually taken in user-data, but of course at a much earlier step (AMI build vs user-data). This will be tested in `stage` prior to `prod` build.